### PR TITLE
update gleam_stdlib & use gleam_regexp instead

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -8,6 +8,7 @@ gleam = ">= 0.33.0"
 [dependencies]
 gleam_stdlib = "~> 0.34"
 gleam_community_colour = "~> 1.3"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_community_colour", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "A49A5E3AE8B637A5ACBA80ECB9B1AFE89FD3D5351FF6410A42B84F666D40D7D5" },
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
+  { name = "gleam_json", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "0A57FB5666E695FD2BEE74C0428A98B0FC11A395D2C7B4CDF5E22C5DD32C74C6" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 gleam_community_colour = { version = "~> 1.3" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.34" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gleam_community/ansi.gleam
+++ b/src/gleam_community/ansi.gleam
@@ -2342,8 +2342,9 @@ pub fn bg_colour(text: String, colour: Colour) -> String {
 /// </div>
 ///
 pub fn strip(text: String) -> String {
-  let regexp_options = regexp.Options(False, True)
-  let assert Ok(r) = regexp.compile("(?:\\[(?:\\d+;?)+m)+", with: regexp_options)
+  let regexp_options = regexp.Options(case_insensitive: False, multi_line: True)
+  let assert Ok(r) =
+    regexp.compile("(?:\\[(?:\\d+;?)+m)+", with: regexp_options)
 
   r
   |> regexp.split(text)

--- a/src/gleam_community/ansi.gleam
+++ b/src/gleam_community/ansi.gleam
@@ -97,7 +97,7 @@
 
 import gleam/int
 import gleam/list
-import gleam/regex
+import gleam/regexp
 import gleam/string
 import gleam_community/colour.{type Colour} as gc_colour
 
@@ -2342,11 +2342,11 @@ pub fn bg_colour(text: String, colour: Colour) -> String {
 /// </div>
 ///
 pub fn strip(text: String) -> String {
-  let regex_options = regex.Options(False, True)
-  let assert Ok(r) = regex.compile("(?:\\[(?:\\d+;?)+m)+", with: regex_options)
+  let regexp_options = regexp.Options(False, True)
+  let assert Ok(r) = regexp.compile("(?:\\[(?:\\d+;?)+m)+", with: regexp_options)
 
   r
-  |> regex.split(text)
+  |> regexp.split(text)
   |> string.join("")
 }
 


### PR DESCRIPTION
Hi y'all! Tiny little 🦃 day change! (Not sure if any of you are Americans but happy completely normal thursday if not)

- updates the stdlib version (and all deps)
- replaces the newly deprecated stdlib regex lib with `gleam_regexp`

Doesn't actually solve the build warnings like I thought it might but still probably worth the change. 

Let me know if you want changes or would rather hold off on the change and I'll just close it for now. Thanks!
