### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.1"
-          gleam-version: "1.5.1"
+          gleam-version: "1.15"
 
       - run: |
           version="v$(cat gleam.toml | grep -m 1 "version" | sed -r "s/version *= *\"([[:digit:].]+)\"/\1/")"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.1"
-          gleam-version: "1.5.1"
+          gleam-version: "1.15"
 
       - run: gleam format --check
 


### PR DESCRIPTION
CI fails because of an old gleam version, so the updated version to use stdlib v1 wasn't published. This fixes it!